### PR TITLE
Add breadcrumbs for curation subpages

### DIFF
--- a/src/components/CurationItem.astro
+++ b/src/components/CurationItem.astro
@@ -16,7 +16,7 @@ const { Content } = await item.render();
   <img class="w-full" src={heroImage} alt={heroImageAlt} />
   <div class="px-0 py-4">
     <div class="font-bold text-xl mb-2 dark:text-gray-200">
-      <a class="visited:text-[#f25042]" href={link}>
+      <a class="hover:underline hover:text-purple-500 visited:text-[#f25042]" href={link}>
         {title}
       </a>
     </div>

--- a/src/components/NavigationLinks.astro
+++ b/src/components/NavigationLinks.astro
@@ -37,7 +37,7 @@ const isActive = (href: string, exact?: boolean): boolean => {
           </a>
         ) : (
           <a
-            class="text-gray-700 hover:text-gray-900 dark:text-white dark:hover:text-gray-400"
+            class="text-gray-700 hover:underline hover:text-purple-500 dark:text-white dark:hover:text-gray-400"
             href={item.href}
           >
             {item.text}

--- a/src/components/ProjectListItem.astro
+++ b/src/components/ProjectListItem.astro
@@ -9,14 +9,21 @@ export interface Props {
 const { project } = Astro.props;
 ---
 
-<li class="dark:text-white my-8">
-  <a
-    class="my-4 text-xl hover:underline visited:text-[#f25042] dark:visited:text-purple-300"
-    href={`/project/${project.slug}/`}
-  >
-    {project.data.title}
-  </a>
-  <p class="text-slate-800 dark:text-slate-300"><i>{project.data.description}</i></p>
+<li
+  class="bg-white dark:bg-slate-800 rounded-lg px-6 py-8 ring-1 ring-slate-900/5 shadow-xl flex-grow-0 flex-[48%]"
+>
+  <img class="w-full" src={project.data.image} alt={project.data.imageAlt} />
+  <div class="font-bold text-xl mb-2 dark:text-gray-200">
+    <a
+      class="hover:underline hover:text-purple-500 visited:text-[#f25042] dark:visited:text-purple-300"
+      href={`/project/${project.slug}/`}
+    >
+      {project.data.title}
+    </a>
+  </div>
+  <p class="text-slate-800 dark:text-slate-300">
+    <i>{project.data.description}</i>
+  </p>
   <div class="flex gap-4">
     <FormattedDate
       class="italic text-slate-600 dark:text-slate-300"

--- a/src/components/WritingListItem.astro
+++ b/src/components/WritingListItem.astro
@@ -11,7 +11,7 @@ const { post } = Astro.props;
 
 <li class="dark:text-white my-8">
   <a
-    class="my-4 text-xl hover:underline visited:text-[#f25042] dark:visited:text-purple-300"
+    class="my-4 text-xl hover:underline hover:text-purple-500 visited:text-[#f25042] dark:visited:text-purple-300"
     href={`/blog/${post.slug}/`}
   >
     {post.data.title}

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -57,6 +57,8 @@ const project = defineCollection({
       .transform((val) => new Date(val)),
     description: z.string(),
     title: z.string(),
+    image: z.string().optional(),
+    imageAlt: z.string().optional(),
   }),
 });
 

--- a/src/content/project/2014-08-06-flitr.md
+++ b/src/content/project/2014-08-06-flitr.md
@@ -6,10 +6,10 @@ description: Flight is a social networking playground
   where users post their profiles and show their pictures.
   It is the penultimate project with DevBootcamp
 # project_link: https://github.com/simongondeck/flight-social-network
-# image: /images/flitr.jpg
+image: /images/flitr.jpg
+imageAlt: Screenshot of Flitr app
 # url: /projects/flitr
 # project_link: https://flitr.herokuapp.com/
-# image: /images/flitr.jpg
 # url: https://flitr.herokuapp.com/
 createdDate: "2014-08-06"
 ---

--- a/src/content/project/2014-08-10-remembrance.md
+++ b/src/content/project/2014-08-10-remembrance.md
@@ -9,7 +9,8 @@ description: Remembrance is the final project of Dev Bootcamp Chicago students
   You can invite friends and family to come together here and share memories,
   whether they be stories or pictures.
 project_link: https://remembrance-dbc.herokuapp.com/
-# image: /images/remembrance.png
+image: /images/remembrance.png
+imageAlt: Screenshot of Remembrance app
 url: https://remembrance-dbc.herokuapp.com/
 createdDate: "2014-08-10"
 ---

--- a/src/content/project/2014-10-05-Groundwater-Hack.md
+++ b/src/content/project/2014-10-05-Groundwater-Hack.md
@@ -9,6 +9,7 @@ description: Underwater groundwater device that allows you to determine
 createdDate: "2014-10-05"
 project_link: https://github.com/groundwaterhack/groundwaterhack.github.io
 # image: /images/flitr.jpg
+# imageAlt: Screenshot of Flitr app
 # url: /projects/ng-pacman
 ---
 

--- a/src/content/project/2015-03-07-philips-hackathon.md
+++ b/src/content/project/2015-03-07-philips-hackathon.md
@@ -8,6 +8,7 @@ description: Healthcare application to help geriatrics.
 # project_link: https://github.com/jermspeaks/coral-reef-game
 createdDate: "2015-03-07"
 # image: /images/flitr.jpg
+# imageAlt: Screenshot of Flitr app
 url: /coral-reef-game
 ---
 

--- a/src/content/project/2015-05-02-pac-man.md
+++ b/src/content/project/2015-05-02-pac-man.md
@@ -5,7 +5,8 @@ name: Pac Man Neurohack Game
 description: Uses your brain waves to control Pacman.
   Entry to Neurogaming Hackathon 2015.
 project_link: https://github.com/jermspeaks/NGHack-Pacman
-# image: /images/flitr.jpg
+image: https://i.imgur.com/DRaLWqM.png
+imageAlt: Pacman screenshot
 # url: /projects/ng-pacman
 createdDate: "2015-05-02"
 ---

--- a/src/content/project/2016-06-04-zika-vr.md
+++ b/src/content/project/2016-06-04-zika-vr.md
@@ -10,6 +10,7 @@ description: As part of National Day of Civic Hacking 2016,
   and effective Zika prevention techniques.
 project_link: https://jermspeaks.github.io/webvr-demo/?polyfill=1
 image: /images/webvr-demo.png
+imageAlt: VR Demo
 url: /projects/zika
 createdDate: "2016-06-04"
 ---

--- a/src/content/project/2017-10-15-Garbage-In-Garbage-Out.md
+++ b/src/content/project/2017-10-15-Garbage-In-Garbage-Out.md
@@ -7,6 +7,7 @@ description:
   Project from Science Hack Day 2017
 project_link: https://jermspeaks.github.io/garbage-in-garbage-out/
 image: /images/gigo.png
+imageAlt: Data visualization for garbage data
 url: /garbage-in-garbage-out
 createdDate: "2017-10-15"
 ---

--- a/src/content/project/2018-10-28-slouching-sloth.md
+++ b/src/content/project/2018-10-28-slouching-sloth.md
@@ -5,6 +5,7 @@ name: No Slouching Sloths
 description: A PSA developed as a project from Science Hack Day 2018
 project_link: https://jermspeaks.github.io/projects/no-slouching-sloths
 image: /images/sloths-first-draft.jpg
+imageAlt: Poster for the slouching sloth
 url: /no-slouching-sloths
 createdDate: "2017-10-15"
 ---

--- a/src/layouts/BookLibraryPost.astro
+++ b/src/layouts/BookLibraryPost.astro
@@ -10,43 +10,38 @@ import type { CollectionEntry } from "astro:content";
 
 type Props = CollectionEntry<"book">["data"];
 
-const { title, heroImage, dateConsumed, heroImageAlt, link } = Astro.props;
+const { blurb, heroImage, dateConsumed, heroImageAlt, link } = Astro.props;
 ---
 
-<html lang="en">
-  <head>
-    <BaseHead title={title} description={SITE_DESCRIPTION} />
-  </head>
-
-  <BaseBody>
-    <Header />
-    <main>
-      <ProseArticle>
-        <h1>{title}</h1>
-        {
-          heroImage && (
-            <img width={230} height={345} src={heroImage} alt={heroImageAlt} />
-          )
-        }
-        {heroImageAlt && (
+<ProseArticle>
+  <!-- <h1>{title}</h1> -->
+  <div class="flex gap-4 border-b-2 pb-2 border-solid border-gray-300 ">
+    <div>
+      {
+        heroImage && (
+          <img width={230} height={345} src={heroImage} alt={heroImageAlt} />
+        )
+      }
+      {
+        heroImageAlt && (
           <figcaption class="text-sm italic">{heroImageAlt}</figcaption>
-        )}
-        <div class="py-4 border-b-2 border-solid border-gray-300 mt-2">
-          <div class="italic text-slate-600 dark:text-slate-300">
-            First Read:
-            <FormattedDate date={dateConsumed} />
-          </div>
-          <a
-            class="italic text-slate-600 dark:text-slate-300"
-            href={link}
-            rel="external"
-          >
-            Affiliate Link
-          </a>
-        </div>
-        <slot />
-      </ProseArticle>
-    </main>
-    <Footer />
-  </BaseBody>
-</html>
+        )
+      }
+    </div>
+    <div class="">
+      <div class="italic text-slate-600 dark:text-slate-300">
+        First Read:
+        <FormattedDate date={dateConsumed} />
+      </div>
+      <a
+        class="italic text-slate-600 dark:text-slate-300"
+        href={link}
+        rel="external"
+      >
+        Affiliate Link
+      </a>
+      <div class="italic text-slate-600 dark:text-slate-300">{blurb}</div>
+    </div>
+  </div>
+  <slot />
+</ProseArticle>

--- a/src/layouts/CollectionDetailsPage.astro
+++ b/src/layouts/CollectionDetailsPage.astro
@@ -7,10 +7,12 @@ import Header from "../components/Header.astro";
 import TitleHeading from "../components/TitleHeading.astro";
 
 type Props = {
+  section: string;
+  sectionSlug: string;
   title: string;
 };
 
-const { title } = Astro.props;
+const { section, sectionSlug, title } = Astro.props;
 ---
 
 <!doctype html>
@@ -28,7 +30,13 @@ const { title } = Astro.props;
           <a href="/curation">Curation</a>
         </span>
         <span class="text-slate-800 dark:text-slate-300">&nbsp;/&nbsp;</span>
-        <span>{title}</span>
+        <span
+          class="text-slate-700 hover:text-slate-500 dark:text-slate-300 dark:hover:text-slate-500"
+        >
+          <a href={`/curation/${sectionSlug}`}>{section}</a>
+        </span>
+        <span class="text-slate-800 dark:text-slate-300">&nbsp;/&nbsp;</span>
+        <span class="font-bold">{title}</span>
       </TitleHeading>
       <slot />
       <Footer />

--- a/src/pages/curation/antibooks/[...slug].astro
+++ b/src/pages/curation/antibooks/[...slug].astro
@@ -1,6 +1,7 @@
 ---
 import { CollectionEntry, getCollection } from "astro:content";
-import LibraryPost from "../../../layouts/LibraryPost.astro";
+import CollectionDetailsPage from "../../../layouts/CollectionDetailsPage.astro";
+import ProseArticle from "../../../components/ProseArticle.astro";
 
 export async function getStaticPaths() {
   const posts = await getCollection("antiLibrary");
@@ -15,8 +16,30 @@ const post = Astro.props;
 const { Content } = await post.render();
 ---
 
-<LibraryPost {...post.data}>
-  <h1>{post.data.title}</h1>
-  <a href={post.data.link}>Purchase Link</a>
-  <Content />
-</LibraryPost>
+<CollectionDetailsPage
+  section="Anti-Library"
+  sectionSlug="antibooks"
+  title={post.data.title}
+>
+  <!-- <h1>{post.data.title}</h1> -->
+  <ProseArticle>
+    {
+      post.data.heroImage && (
+        <img
+          width={300}
+          height={150}
+          src={post.data.heroImage}
+          alt={post.data.heroImageAlt}
+          title={post.data.heroImageAlt}
+        />
+      )
+    }
+    {
+      post.data.heroImageAlt && (
+        <figcaption class="text-sm italic">{post.data.heroImageAlt}</figcaption>
+      )
+    }
+    <a href={post.data.link}>Purchase Link</a>
+    <Content />
+  </ProseArticle>
+</CollectionDetailsPage>

--- a/src/pages/curation/antibooks/index.astro
+++ b/src/pages/curation/antibooks/index.astro
@@ -47,7 +47,7 @@ const antiLibrary = (await getCollection("antiLibrary")).sort(
           <li class="flex flex-shrink-0 flex-grow-0 flex-col flex-[200px] rounded-sm box-border dark:text-white">
             <a
               class="visited:text-[#f25042]"
-              href={`/library/antibooks/${entry.slug}`}
+              href={`/curation/antibooks/${entry.slug}`}
             >
               <img
                 alt={entry.data.heroImageAlt}

--- a/src/pages/curation/books/[...slug].astro
+++ b/src/pages/curation/books/[...slug].astro
@@ -1,6 +1,7 @@
 ---
 import { CollectionEntry, getCollection } from 'astro:content';
 import BookLibraryPost from '../../../layouts/BookLibraryPost.astro';
+import CollectionDetailsPage from '../../../layouts/CollectionDetailsPage.astro';
 
 export async function getStaticPaths() {
 	const posts = await getCollection('book');
@@ -15,6 +16,8 @@ const post = Astro.props;
 const { Content } = await post.render();
 ---
 
-<BookLibraryPost {...post.data}>
-	<Content />
-</BookLibraryPost>
+<CollectionDetailsPage section="Library" sectionSlug="books" title={post.data.title}>
+	<BookLibraryPost {...post.data}>
+		<Content />
+	</BookLibraryPost>
+</CollectionDetailsPage>

--- a/src/pages/curation/books/index.astro
+++ b/src/pages/curation/books/index.astro
@@ -16,7 +16,7 @@ const bookLibrary = (await getCollection("book")).sort(
           <li class="flex flex-shrink-0 flex-grow-0 flex-col flex-[200px] rounded-sm box-border dark:text-white">
             <a
               class="visited:text-[#f25042]"
-              href={`/library/books/${book.slug}`}
+              href={`/curation/books/${book.slug}`}
             >
               <img
                 alt={book.data.heroImageAlt}

--- a/src/pages/curation/businesscards/index.astro
+++ b/src/pages/curation/businesscards/index.astro
@@ -17,7 +17,7 @@ import CurationDetailsPage from "../../../layouts/CurationDetailsPage.astro";
           <li class="flex flex-shrink-0 flex-grow-0 flex-col flex-[200px] rounded-sm box-border dark:text-white">
             <a
               class="visited:text-[#f25042]"
-              href={`/library/films/${film.slug}`}
+              href={`/curation/films/${film.slug}`}
             >
               <img
                 alt={film.data.heroImageAlt}

--- a/src/pages/curation/films/index.astro
+++ b/src/pages/curation/films/index.astro
@@ -16,7 +16,7 @@ const filmLibrary = (await getCollection("filmLibrary")).sort(
           <li class="flex flex-shrink-0 flex-grow-0 flex-col flex-[200px] rounded-sm box-border dark:text-white">
             <a
               class="visited:text-[#f25042]"
-              href={`/library/films/${film.slug}`}
+              href={`/curation/films/${film.slug}`}
             >
               <img
                 alt={film.data.heroImageAlt}

--- a/src/pages/curation/index.astro
+++ b/src/pages/curation/index.astro
@@ -5,7 +5,7 @@ import CurationPage from "../../layouts/CurationPage.astro";
 import ProseArticle from "../../components/ProseArticle.astro";
 import CurationItem from "../../components/CurationItem.astro";
 
-const TOTAL_NUMBER_OF_ITEMS = 5;
+const TOTAL_NUMBER_OF_ITEMS = 6;
 const bookLibrary = (await getCollection("book"))
   .sort((a, b) => b.data.dateConsumed.valueOf() - a.data.dateConsumed.valueOf())
   .map((item) => ({
@@ -35,7 +35,7 @@ const lindyLibrary = (await getCollection("lindy"))
     },
   }));
 
-// Combines all of the collections and finds the latest 5 items
+// Combines all of the collections and finds the latest `TOTAL_NUMBER_OF_ITEMS` items
 const combination = [...bookLibrary, ...filmLibrary, ...lindyLibrary]
   .sort((a, b) => b.data.dateConsumed.valueOf() - a.data.dateConsumed.valueOf())
   .slice(0, TOTAL_NUMBER_OF_ITEMS);
@@ -70,21 +70,23 @@ const curations = (await getCollection("curation")).sort((a, b) =>
     <ul class="grid grid-cols-1 lg:grid-cols-2 gap-4 list-none p-0">
       {
         combination.map((item) => (
-          <li class="flex flex-shrink-0 flex-grow-0 flex-row flex-wrap flex-[100%] md:flex-[48%] mb-6 md:mb-0 rounded-sm box-border dark:text-white">
-            <a
-              class="flex-shrink-0 flex-grow-0 flex-[200px] visited:text-[#f25042]"
-              href={`/curation/${item.data.type}/${item.slug}`}
-            >
-              <img
-                src={item.data.heroImage}
-                class="aspect-auto w-full"
-                alt={item.data.heroImageAlt}
-              />
-            </a>
-            <div class="md:py-0 md:px-4 mt-2 md:mt-0">
+          <li class="flex flex-col sm:flex-row flex-[100%] sm:flex-[48%] gap-4 mb-6 md:mb-0 rounded-sm box-border dark:text-white">
+            <div class="flex-shrink-0 flex-grow-0 flex-initial sm:w-32">
+              <a
+                class="visited:text-[#f25042]"
+                href={`/curation/${item.data.type}/${item.slug}`}
+              >
+                <img
+                  src={item.data.heroImage}
+                  class="aspect-auto w-full sm:w-32"
+                  alt={item.data.heroImageAlt}
+                />
+              </a>
+            </div>
+            <div class="md:py-0 md:px-0 mt-2 md:mt-0">
               <div class="font-bold mb-2">
                 <a
-                  class="hover:text-purple-500 visited:text-[#f25042]"
+                  class="hover:underline hover:text-purple-500 visited:text-[#f25042]"
                   href={`/curation/${item.data.type}/${item.slug}`}
                 >
                   {item.data.title}

--- a/src/pages/curation/lindy/index.astro
+++ b/src/pages/curation/lindy/index.astro
@@ -19,7 +19,7 @@ const lindyLibrary = (await getCollection("lindy")).sort((a, b) =>
       {
         lindyLibrary.map((lindyItem) => (
           <li class="flex rounded-sm box-border p-4 bg-slate-100 dark:bg-slate-800 dark:text-white">
-            <a href={`/library/lindy/${lindyItem.slug}`} title={lindyItem.data.title}>
+            <a href={`/curation/lindy/${lindyItem.slug}`} title={lindyItem.data.title}>
               {lindyItem.data.title}
             </a>
           </li>

--- a/src/pages/curation/log/index.astro
+++ b/src/pages/curation/log/index.astro
@@ -1,10 +1,6 @@
 ---
 import { getCollection } from "astro:content";
-import { SITE_TITLE, SITE_DESCRIPTION } from "../../../consts";
-import BaseBody from "../../../components/BaseBody.astro";
-import BaseHead from "../../../components/BaseHead.astro";
-import Footer from "../../../components/Footer.astro";
-import Header from "../../../components/Header.astro";
+import CurationDetailsPage from "../../../layouts/CurationDetailsPage.astro";
 import ProseArticle from "../../../components/ProseArticle.astro";
 import TitleHeading from "../../../components/TitleHeading.astro";
 
@@ -13,34 +9,23 @@ const logs = (await getCollection("log")).sort(
 );
 ---
 
-<!DOCTYPE html>
-<html lang="en">
-  <head>
-    <BaseHead title={SITE_TITLE} description={SITE_DESCRIPTION} />
-  </head>
-  <BaseBody>
-    <Header />
-    <main class="max-w-[65ch] mx-auto">
-      <TitleHeading>Logs by Year</TitleHeading>
-      <ProseArticle>
-        <p>
-          These are logs of consumed media from the past few years. (Updates in
-          Progress).
-        </p>
-        <p>I've been logging media consumption since 2010.</p>
-        <ul>
-          {
-            logs.map((log) => (
-              <li>
-                <a href={`/curation/log/${log.slug}/`} title={log.data.title}>
-                  {log.data.title}
-                </a>
-              </li>
-            ))
-          }
-        </ul>
-      </ProseArticle>
-    </main>
-    <Footer />
-  </BaseBody>
-</html>
+<CurationDetailsPage title="Logs by Year">
+  <ProseArticle>
+    <p>
+      These are logs of consumed media from the past few years. (Updates in
+      Progress).
+    </p>
+    <p>I've been logging media consumption since 2010.</p>
+    <ul>
+      {
+        logs.map((log) => (
+          <li>
+            <a href={`/curation/log/${log.slug}/`} title={log.data.title}>
+              {log.data.title}
+            </a>
+          </li>
+        ))
+      }
+    </ul>
+  </ProseArticle>
+</CurationDetailsPage>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -90,14 +90,14 @@ const latestFilms = (await getCollection("filmLibrary"))
       <div class="flex flex-col max-w-[65ch] lg:max-w-[80ch] mx-auto">
         <div>
           <h3 class="text-3xl font-medium underline">
-            <a href="/library/books">Latest Books</a>
+            <a href="/curation/books">Latest Books</a>
           </h3>
           <ul class="flex flex-wrap list-none p-0 gap-2 mt-8 mb-8">
             {
               latestBooks.map((book) => (
                 <li class="flex flex-shrink-0 flex-grow-0 flex-col rounded-sm box-border dark:text-white">
                   <a
-                    href={`/library/books/${book.slug}`}
+                    href={`/curation/books/${book.slug}`}
                     title={book.data.title}
                   >
                     <img
@@ -114,7 +114,7 @@ const latestFilms = (await getCollection("filmLibrary"))
         </div>
         <div>
           <h3 class="text-3xl font-medium underline">
-            <a href="/library/films">Latest Films</a>
+            <a href="/curation/films">Latest Films</a>
           </h3>
           <ul class="flex flex-wrap list-none p-0 gap-2 mt-8 mb-8">
             {
@@ -122,7 +122,7 @@ const latestFilms = (await getCollection("filmLibrary"))
                 <li class="flex flex-shrink-0 flex-grow-0 flex-col rounded-sm box-border dark:text-white">
                   {film.data.heroImage && (
                     <a
-                      href={`/library/films/${film.slug}`}
+                      href={`/curation/films/${film.slug}`}
                       title={film.data.title}
                     >
                       <img

--- a/src/pages/project/index.astro
+++ b/src/pages/project/index.astro
@@ -21,10 +21,10 @@ const projects = (await getCollection("project")).sort(
   </head>
   <BaseBody>
     <Header />
-    <main class="max-w-[65ch] mx-auto">
+    <main class="max-w-[85ch] mx-auto">
       <TitleHeading>Projects</TitleHeading>
       <section>
-        <ul class="list-none p-0">
+        <ul class="list-none p-0 grid grid-cols-1 md:grid-cols-2 gap-4">
           {projects.map((project) => <ProjectListItem project={project} />)}
         </ul>
       </section>

--- a/src/pages/rss.xml.js
+++ b/src/pages/rss.xml.js
@@ -14,11 +14,11 @@ export async function get(context) {
   }));
   const bookCollection = books.map((book) => ({
     ...book.data,
-    link: `/library/books/${book.slug}/`,
+    link: `/curation/books/${book.slug}/`,
   }));
   const filmCollection = films.map((film) => ({
     ...film.data,
-    link: `/library/films/${film.slug}/`,
+    link: `/curation/films/${film.slug}/`,
   }));
   const items = [...postCollection, ...bookCollection, ...filmCollection].sort(
     (a, b) => b.pubDate.valueOf() - a.pubDate.valueOf()


### PR DESCRIPTION
- Fixed the conversion of `/library` to `/curation` for the subpages on books and films
- Converted internal links to hover purple
- Added breadcrumbs for subpages in library and antilibrary